### PR TITLE
Message threads added

### DIFF
--- a/WaffleOffer/WaffleOffer/Controllers/MessagesController.cs
+++ b/WaffleOffer/WaffleOffer/Controllers/MessagesController.cs
@@ -20,14 +20,19 @@ namespace WaffleOffer.Controllers
         #endregion
 
         #region view/display
-        // PERMISSIONS ONLY FOR TESTING. REMOVE ASAP. !IMPORTANT
-        [AllowAnonymous]
+        // MESSAGE INBOX
         public ActionResult Inbox()
         {
+            // Create lists of message and message view model objects
+            // to hold the inbox messages
             List<Message> messages = new List<Message>();
             List<MessageViewModel> messageVms = new List<MessageViewModel>();
+            // Get the id of the current logged-in user
             string userId = User.Identity.GetUserId();
 
+            // If there's a user, get that user's messages, make sure that
+            // there are more than zero messages, and then convert those message
+            // objects into view model objects
             if (userId != null)
             {
                 messages = GetInboxMessages(userId);
@@ -38,8 +43,7 @@ namespace WaffleOffer.Controllers
             return View(messageVms);
         }
 
-        // PERMISSIONS ONLY FOR TESTING. REMOVE ASAP. !IMPORTANT
-        [AllowAnonymous]
+        // SENT MESSAGES PAGE
         public ActionResult Sent()
         {
             List<Message> messages = new List<Message>();
@@ -56,25 +60,29 @@ namespace WaffleOffer.Controllers
             return View(messageVms);
         }
 
-        // PERMISSIONS ONLY FOR TESTING. REMOVE ASAP. !IMPORTANT
-        // TODO: MAKE IT DISPLAY A VIEW MODEL VERSION
-        [AllowAnonymous]
-        // GET: /Messages/View/5
         public ActionResult View(int? id)
         {
             if (id == null)
             {
                 return new HttpStatusCodeResult(HttpStatusCode.BadRequest);
             }
+            // Get the message
             Message message = db.Messages.Find(id);
             if (message == null)
             {
                 return HttpNotFound();
             }
-            MessageViewModel messageVm = GetMessageVM(message);
-            return View(messageVm);
+
+            // Get all of the messages in this message thread (sorted by thread position)
+            List<Message> messages = GetSortedThreadMessages(message.ThreadID);
+            List<MessageViewModel> messageVms = GetMessageVMs(messages);
+
+            ViewBag.LatestMessagePanelID = "collapse" + (messageVms.Count - 1);
+
+            return View(messageVms);
         }
 
+        // CUSTOM ERROR PAGE
         public ActionResult Error()
         {
             return View();
@@ -83,12 +91,11 @@ namespace WaffleOffer.Controllers
         #endregion
 
         #region create/compose
-        // PERMISSIONS ONLY FOR TESTING. REMOVE ASAP. !IMPORTANT
-        [AllowAnonymous]
         // GET: /Messages/Compose
-        public ActionResult Compose(string recipientUsername)
+        public ActionResult Compose(string recipientUsername, bool isReply, int threadId, int threadPos)
         {
             ViewBag.Recipient = recipientUsername;
+            //ViewBag.ThreadPos = threadPos;
             return View();
         }
 
@@ -96,37 +103,54 @@ namespace WaffleOffer.Controllers
         // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
 
-        // PERMISSIONS ONLY FOR TESTING. REMOVE ASAP. !IMPORTANT
-        [AllowAnonymous]
         [HttpPost]
         [ValidateAntiForgeryToken]
-        // TODO: Investigate whether or not RecipientItem and SenderItem need to be bound (esp. if it blows up. which it might.)
-        public ActionResult Compose([Bind(Include = "MessageID,Subject,Body")] MessageViewModel msgVm, string recipientUsername)
+        public ActionResult Compose([Bind(Include = "MessageID,Subject,Body,ThreadID")] MessageViewModel msgVm, string recipientUsername, bool isReply, int threadId, int threadPos)
         {
             if (ModelState.IsValid)
             {
+                // Put the recipient's name in the viewbag and getthe user id of 
+                // the sender
                 ViewBag.Recipient = recipientUsername;
+
                 string senderId = User.Identity.GetUserId();
 
-                //AppUser recipient = GetRecipientByUserName(msgVm.RecipientUserName);
-                //if (recipient != null)
-                //{
-                    //string recipientId = recipient.UserName;
-                    AppUser recipient = GetRecipientByUserName(recipientUsername);
-                    string recipientId = recipient.Id;
-                    Message msg = CreateMessageFromVM(msgVm, recipientId, senderId);
+                // Get the recipient's AppUser object by username and get the id of
+                // the recipient from the AppUser object
+                AppUser recipient = GetRecipientByUserName(recipientUsername);
+                string recipientId = recipient.Id;
 
-                    db.Messages.Add(msg);
+                if (isReply == false)
+                {
+                    // Create a new thread
+                    Thread thread = new Thread();
+                    // Add thread to DB and save changes
+                    db.Threads.Add(thread);
                     db.SaveChanges();
 
-                    bool sent = SendMessage(msg);
+                    msgVm.ThreadID = thread.ThreadID;
+                    //msgVm.ThreadPosition = threadPos;
+                }
 
-                    if (sent)
-                        return RedirectToAction("Inbox");
-                    else
-                        return RedirectToAction("Error");
-                //}
-                // TODO: Let the user know that no such user exists
+                msgVm.ThreadPosition = threadPos;
+
+                // Create a new message object by passinging the message (view model 
+                // version) as well as the ids of the recipient and the sender into 
+                // the CreateMessageFromVM method
+                Message msg = CreateMessageFromVM(msgVm, recipientId, senderId, isReply);
+                
+                // Add the message object to the databases and save the changes
+                db.Messages.Add(msg);
+                db.SaveChanges();
+
+                // Send the message using the SendMessage method. If it is sent,
+                // it will return true. If not, it will return false.
+                bool sent = SendMessage(msg);
+
+                if (sent)
+                    return RedirectToAction("Inbox");
+                else
+                    return RedirectToAction("Error");
             }
 
             return RedirectToAction("Error");
@@ -135,11 +159,7 @@ namespace WaffleOffer.Controllers
         #endregion
 
         #region edit/update
-        // !IMPORTANT: EDIT/UPDATE MESSAGE IS LOW-PRIORITY
-
         // GET: /Messages/Edit/5
-        // PERMISSIONS ONLY FOR TESTING. REMOVE ASAP. !IMPORTANT
-        [AllowAnonymous]
         public ActionResult Edit(int? id)
         {
             if (id == null)
@@ -151,7 +171,7 @@ namespace WaffleOffer.Controllers
             {
                 return HttpNotFound();
             }
-            // Check the "sent" flag. Do not allow editing of messages that have
+            // Check the "sent" flag. Disallow the editing of messages that have
             // already been sent.
             if (message.Sent != true)
             {
@@ -164,9 +184,6 @@ namespace WaffleOffer.Controllers
         // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
 
-        // PERMISSIONS ONLY FOR TESTING. REMOVE ASAP. !IMPORTANT
-        [AllowAnonymous]
-        // TODO: Use the MessageViewModel
         [HttpPost]
         [ValidateAntiForgeryToken]
         public ActionResult Edit([Bind(Include = "MessageID,SenderID,RecipientID,Subject,Body,DateCreated,DateSent,Sent")] Message message)
@@ -183,8 +200,6 @@ namespace WaffleOffer.Controllers
         #endregion
 
         #region delete
-        // PERMISSIONS ONLY FOR TESTING. REMOVE ASAP. !IMPORTANT
-        [AllowAnonymous]
         // GET: /Messages/Delete/5
         public ActionResult Delete(int? id)
         {
@@ -192,7 +207,10 @@ namespace WaffleOffer.Controllers
             {
                 return new HttpStatusCodeResult(HttpStatusCode.BadRequest);
             }
+            // Find and retrieve the message by its id.
             Message message = db.Messages.Find(id);
+            // Make a view model version of the message so that a user can
+            // review it before confirming deletion.
             MessageViewModel messageVm = GetMessageVM(message);
             if (message == null)
             {
@@ -201,8 +219,6 @@ namespace WaffleOffer.Controllers
             return View(messageVm);
         }
 
-        // PERMISSIONS ONLY FOR TESTING. REMOVE ASAP. !IMPORTANT
-        [AllowAnonymous]
         // POST: /Messages/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
@@ -245,11 +261,19 @@ namespace WaffleOffer.Controllers
 
             // Get the messages with a RecipientID matching the user's id and that have been
             // marked as having been sent
-            inboxMessages = (from m in db.Messages
+            var allInboxMessages = (from m in db.Messages
                              where m.RecipientID == userId && m.Sent == true && m.Copy == true
                              select m).ToList();
+            /* // TODO: DEBUG. THIS CODE STILL LOADS DUPES. 
+            foreach (var msg in allInboxMessages)
+            {
+                Message latestMessage = GetThreadLatestMessage(userId, msg.ThreadID);
+                inboxMessages.Add(latestMessage);
+            }
 
             return inboxMessages;
+             */
+            return allInboxMessages;
         }
 
         // Get all messages in which the user is the sender
@@ -259,11 +283,19 @@ namespace WaffleOffer.Controllers
 
             // Get the messages with a SenderID matching the user's id and that have been
             // marked as having been sent
-            sentMessages = (from m in db.Messages
+            var allSentMessages = (from m in db.Messages
                             where m.SenderID == userId && m.Sent == true && m.Copy == false
                             select m).ToList();
+            /* // TODO: DEBUG. THIS CODE STILL LOADS DUPES.
+            foreach (var msg in allSentMessages)
+            {
+                Message latestMessage = GetThreadLatestMessage(userId, msg.ThreadID);
+                sentMessages.Add(latestMessage);
+            }
 
             return sentMessages;
+             */
+            return allSentMessages;
         }
 
         // Get the message sender for the message that matches the
@@ -317,6 +349,9 @@ namespace WaffleOffer.Controllers
                 msgVm.DateSent = msg.DateSent;
                 msgVm.Sent = msg.Sent;
                 msgVm.Copy = msg.Copy;
+                msgVm.IsReply = msg.IsReply;
+                msgVm.ThreadID = msg.ThreadID;
+                msgVm.ThreadPosition = msg.ThreadPosition;
             }
 
             return msgVm;
@@ -349,11 +384,70 @@ namespace WaffleOffer.Controllers
             return user;
         }
 
+        /* 
+          Retrieves messages in a given message thread, sorts by position in
+          a thread (or it would if I could get it working properly), and then
+          returns a list of messages that differs depending on whether or not
+          the user is the recipient or the sender (to avoid returning both
+          copies and originals).
+        */ 
+        public List<Message> GetSortedThreadMessages(int threadId)
+        {
+            List<Message> userMessages = new List<Message>();
+            string userId = User.Identity.GetUserId();
+
+            var allThreadMessages = (from m in db.Messages
+                        where m.ThreadID == threadId
+                        orderby m.ThreadPosition ascending 
+                        select m).ToList();
+
+            foreach (var msg in allThreadMessages)
+            {
+                if (userId == msg.RecipientID)
+                {
+                    if (msg.Copy == true)
+                        userMessages.Add(msg);
+                }
+                else if (userId == msg.SenderID)
+                {
+                    if (msg.Copy == false)
+                        userMessages.Add(msg);
+                }
+            }
+
+            return userMessages;
+        }
+
+        // Retrieves the last message in a message thread. BUGGY. Probable
+        // logic errors. DEBUG.
+        public Message GetThreadLatestMessage(string userId, int threadId)
+        {
+            List<Message> messages = new List<Message>();
+            Message msg = new Message();
+
+            // Get the messages with a RecipientID matching the user's id and that have been
+            // marked as having been sent
+            if (threadId >= 0)
+            {
+                messages = GetSortedThreadMessages(threadId);
+                int numMessages = messages.Count;
+                int latestMessageNum;
+                if (numMessages > 0)
+                {
+                    latestMessageNum = numMessages - 1;
+                    msg = messages[latestMessageNum];
+                }
+            }
+            return msg;
+        }
+
         #endregion
 
         # region create functions
-        // TODO: Make sure that the "sent" flag is necessary
-        public Message CreateMessageFromVM(MessageViewModel msgVm, string recipientId, string senderId)
+        // Because the messages that the user will be interacting with 
+        // will be the view model versions, it is necessary to be able
+        // to convert MessageViewModel objects back into Message objects.
+        public Message CreateMessageFromVM(MessageViewModel msgVm, string recipientId, string senderId, bool isReply)
         {
             Message msg = new Message();
 
@@ -363,12 +457,20 @@ namespace WaffleOffer.Controllers
                 msg.RecipientID = recipientId;
                 msg.Subject = msgVm.Subject;
                 msg.Body = msgVm.Body;
-                //msg.DateCreated = msgVm.DateCreated;
                 msg.DateCreated = DateTime.Now;
                 msg.DateSent = DateTime.Now;
                 msg.Sent = false;
-                //msg.Copy = msgVm.Copy;
                 msg.Copy = false;
+                msg.IsReply = isReply;
+                msg.ThreadID = msgVm.ThreadID;
+                msgVm.ThreadPosition = msg.ThreadPosition;
+
+                /*
+                if (isReply == true)
+                    msgVm.ThreadPosition = msg.ThreadPosition + 1;
+                else
+                    msgVm.ThreadPosition = msg.ThreadPosition;
+                */ 
             }
 
             return msg;
@@ -398,29 +500,25 @@ namespace WaffleOffer.Controllers
             msgCopy.DateSent = DateTime.Now;
             msgCopy.Sent = true;
             msgCopy.Copy = true;
+            msgCopy.IsReply = msg.IsReply;
+            msgCopy.ThreadID = msg.ThreadID;
+            msgCopy.ThreadPosition = msg.ThreadPosition;
 
             // Get the recipient AppUser object
             AppUser recipient = db.Users.Find(msg.RecipientID);
 
             // If the recipient exists, add the copy to database,
-            // mark the original message as being sent, save those
-            // changes to the database, and then add the copy
-            // to the recipient's messages list. That last bit might
-            // not be necessary.
+            // mark the original message as being sent, and save those
+            // changes to the database.
             if (recipient != null)
             {
                 db.Messages.Add(msgCopy);
                 msg.Sent = true;
                 db.SaveChanges();
                 sent = true;
-                //recipient.UserMessages.Add(msgCopy);
             }
-            // TODO: Error handling, etc.
-            // TODO: Let the user know that the message was sent
             return sent;
         }
-
-        // TODO: Save draft
 
         #endregion
 

--- a/WaffleOffer/WaffleOffer/Models/Message.cs
+++ b/WaffleOffer/WaffleOffer/Models/Message.cs
@@ -19,5 +19,9 @@ namespace WaffleOffer.Models
         public bool Sent { get; set; }
         public bool Copy { get; set; }
         //public bool Saved { get; set; }
+        public bool IsReply { get; set; }
+        public int ThreadID { get; set; }
+        public int ThreadPosition { get; set; }
+
     }
 }

--- a/WaffleOffer/WaffleOffer/Models/MessageViewModel.cs
+++ b/WaffleOffer/WaffleOffer/Models/MessageViewModel.cs
@@ -35,5 +35,8 @@ namespace WaffleOffer.Models
         public bool Sent { get; set; }
         public bool Copy { get; set; }
         //public bool Saved { get; set; }
+        public bool IsReply { get; set; }
+        public int ThreadID { get; set; }
+        public int ThreadPosition { get; set; }
     }
 }

--- a/WaffleOffer/WaffleOffer/Models/Thread.cs
+++ b/WaffleOffer/WaffleOffer/Models/Thread.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Web;
+
+namespace WaffleOffer.Models
+{
+    public class Thread
+    {
+        List<Message> messages = new List<Message>();
+
+        [Key]
+        public int ThreadID { get; set; }
+        public List<Message> ThreadMessages { get { return messages; } set { messages = value; } }
+    }
+}

--- a/WaffleOffer/WaffleOffer/Models/WaffleOfferContext.cs
+++ b/WaffleOffer/WaffleOffer/Models/WaffleOfferContext.cs
@@ -13,6 +13,7 @@ namespace WaffleOffer.Models
         {
         }
 
+        public System.Data.Entity.DbSet<Thread> Threads { get; set; }
         public System.Data.Entity.DbSet<Item> Items { get; set; }
         public System.Data.Entity.DbSet<Message> Messages { get; set; }
         public System.Data.Entity.DbSet<Trade> Trades { get; set; }

--- a/WaffleOffer/WaffleOffer/Views/Messages/Compose.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Messages/Compose.cshtml
@@ -25,6 +25,8 @@
         @Html.ValidationSummary(true)
         @Html.HiddenFor(model => model.DateCreated)
         @Html.HiddenFor(model => model.DateSent)
+        @Html.HiddenFor(model => model.ThreadID)
+        @Html.HiddenFor(model => model.ThreadPosition)
 
         <div class="form-group">
             <label class="control-label col-md-2">To</label>

--- a/WaffleOffer/WaffleOffer/Views/Messages/View.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Messages/View.cshtml
@@ -1,7 +1,8 @@
-﻿@model WaffleOffer.Models.MessageViewModel
+﻿@model IEnumerable<WaffleOffer.Models.MessageViewModel>
 
 @{
     ViewBag.Title = "View Message";
+    int counter = 0;
 }
 <h4 class="dark-heading">View Message</h4>
 <p>
@@ -16,23 +17,65 @@
         </ul>
     </div>
 </p>
-<div>
-    <ul class="collection">
-        <li class="collection-item">
-            <span class="msg-label">Sender: &nbsp;</span> @Html.DisplayFor(model => model.SenderItem.UserName)<br />
-            <span class="msg-label">Recipient: &nbsp;</span> @Html.DisplayFor(model => model.RecipientItem.UserName)<br />
-            <span class="msg-label">Sent: &nbsp;</span> @Html.DisplayFor(model => model.DateSent)<br />
-            <span class="msg-label">@Html.DisplayNameFor(model => model.Subject): &nbsp;</span> @Html.DisplayFor(model => model.Subject) <br />
-            @Html.DisplayFor(model => model.Body) <br />
-            @if (User.Identity.Name == Model.RecipientItem.UserName)
-            {
-              @Html.ActionLink("Reply", "Compose", new { recipientUsername = Model.SenderItem.UserName }, new { @class = "btn btn-sm btn-custom-grey", @title = "Reply" })
-            }
-        </li>
-        <!--
-        <li class="collection-item"><span class="msg-label">@Html.DisplayNameFor(model => model.Subject): &nbsp;</span> @Html.DisplayFor(model => model.Subject)</li>
-        <li class="collection-item"><span class="msg-label">@Html.DisplayNameFor(model => model.Body): &nbsp;</span>@Html.DisplayFor(model => model.Body)</li>
-        -->
-    </ul>
+<div class="panel-group" id="accordion">
+@foreach (var item in Model)
+{
+    string panelId = "collapse" + counter;
+    string toggleId = "#" + panelId;
+      
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <div class="panel-title">
+                <a data-toggle="collapse" href="@toggleId">
+                    @Html.HiddenFor(modelItem => item.ThreadID)
+                    @Html.HiddenFor(modelItem => item.ThreadPosition)
+
+                    @if (User.Identity.Name == item.SenderItem.UserName)
+                    {
+                        @Html.HiddenFor(modelItem => item.SenderItem.UserName)
+                    }
+                    else
+                    {
+                        <span class="msg-label">Sender: &nbsp;</span> @Html.DisplayFor(modelItem => item.SenderItem.UserName)<br />
+                    }
+                    
+                    @if (User.Identity.Name == item.RecipientItem.UserName)
+                    {
+                        @Html.HiddenFor(modelItem => item.RecipientItem.UserName)
+                    }
+                    else
+                    {
+                        <span class="msg-label">Recipient: &nbsp;</span> @Html.DisplayFor(modelItem => item.RecipientItem.UserName)<br />
+                    }
+                    
+                    <span class="msg-label">Sent: &nbsp;</span> @Html.DisplayFor(modelItem => item.DateSent)<br />
+                    <span class="msg-label">Subject: &nbsp;</span> @Html.DisplayFor(modelItem => item.Subject)<br />
+                    <i class="material-icons">expand_more</i>
+                </a>
+            </div>
+        </div>
+        @if (panelId == ViewBag.LatestMessagePanelID) {
+            <div id="@panelId" class="panel-collapse collapse in">
+                <div class="panel-body">
+                    @Html.DisplayFor(modelItem => item.Body) <br />
+                    @if (User.Identity.Name == item.RecipientItem.UserName)
+                {
+                        @Html.ActionLink("Reply", "Compose", new { recipientUsername = item.SenderItem.UserName, isReply = true, threadId = item.ThreadID, threadPos = (item.ThreadPosition + 1) }, new { @class = "btn btn-sm btn-custom-grey", @title = "Reply" })
+                }
+                </div>
+            </div>
+        }
+        <div id="@panelId" class="panel-collapse collapse">
+            <div class="panel-body">
+                @Html.DisplayFor(modelItem => item.Body) <br />
+                @if (User.Identity.Name == item.RecipientItem.UserName)
+                {
+                  @Html.ActionLink("Reply", "Compose", new { recipientUsername = item.SenderItem.UserName, isReply = true, threadId = item.ThreadID, threadPos = (item.ThreadPosition + 1) }, new { @class = "btn btn-sm btn-custom-grey", @title = "Reply" })
+                }
+            </div>
+        </div>
+    </div>
+    counter++;
+}
 </div>
 

--- a/WaffleOffer/WaffleOffer/Views/Profile/Index.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Profile/Index.cshtml
@@ -18,7 +18,7 @@
             @if (User.Identity.Name != Model.Nickname)
             {
                 <div class="col-md-offset-1">
-                    @Html.ActionLink("Send Message", "Compose", "Messages", new { recipientUsername = Model.Nickname }, new { @class="btn btn-sm btn-custom-grey" })
+                    @Html.ActionLink("Send Message", "Compose", "Messages", new { recipientUsername = Model.Nickname, isReply = false, threadId = -1, threadPos = 0 }, new { @class="btn btn-sm btn-custom-grey" })
                 </div>
             }
         </div>

--- a/WaffleOffer/WaffleOffer/WaffleOffer.csproj
+++ b/WaffleOffer/WaffleOffer/WaffleOffer.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Models\ProfileViewModel.cs" />
     <Compile Include="Models\RegisterViewModel.cs" />
     <Compile Include="Models\Search.cs" />
+    <Compile Include="Models\Thread.cs" />
     <Compile Include="Models\Trade.cs" />
     <Compile Include="Models\TradeCreator.cs" />
     <Compile Include="Models\Trader.cs" />
@@ -185,6 +186,8 @@
     <Content Include="Content\bootstrap.css" />
     <Content Include="Content\bootstrap.min.css" />
     <Content Include="Content\custom.css" />
+    <Content Include="Content\mdb.css" />
+    <Content Include="Content\mdb.min.css" />
     <Content Include="favicon.ico" />
     <Content Include="fonts\glyphicons-halflings-regular.svg" />
     <Content Include="Global.asax" />
@@ -195,6 +198,8 @@
     <None Include="Scripts\jquery-1.10.2.intellisense.js" />
     <Content Include="Scripts\jquery-1.10.2.js" />
     <Content Include="Scripts\jquery-1.10.2.min.js" />
+    <Content Include="Scripts\mdb.js" />
+    <Content Include="Scripts\mdb.min.js" />
     <Content Include="Scripts\modernizr-2.6.2.js" />
     <Content Include="Scripts\respond.js" />
     <Content Include="Scripts\respond.min.js" />


### PR DESCRIPTION
- Created a Thread model to keep track of message threads
- Added many methods to the MessagesController to deal with threads
- Adjusted existing methods to play nice with threads
- Message exchanges are now (successfully!) attached to a thread
- All messages in an exchange thread now appear when a single message in that thread is viewed
- Message threads now appear on collapsible/accordion panels instead of in a collapsible collection
- Added an icon to make it clear that the message headings can be expanded to see the message body
- When viewing a message, the latest message in its thread now opens uncollapsed, while older messaged load collapsed
- Added A LOT of documentation to the MessagesController
- The position of a message in a thread is broken, but other than that feature not (yet) working, it doesn't break anything else. Its brokenness is a quiet sort of brokenness. Like someone freezing to death in the frigid, empty expanses of northern Canada.
