### PR TITLE
Lots of UI changes, trade view overhauled

### DIFF
--- a/WaffleOffer/WaffleOffer/Content/custom.css
+++ b/WaffleOffer/WaffleOffer/Content/custom.css
@@ -248,9 +248,13 @@ footer address {
     border: solid #ffc90e 2px;
     color: #f8b10e;
 }
+.btn-sender, .btn-receiver {
+    display: block;
+    float: left;
+}
 
 .btn-sender:hover,
-.btn-send:focus {
+.btn-sender:focus {
     background-color: #fff;
     border:#00B3FF solid 2px;
     color:#00B3FF;
@@ -274,7 +278,6 @@ footer address {
     background-color: #fff;
     color: #ffc90e;
 }
-
 
 /* Icon Styles */
 .icon-link-light {
@@ -411,7 +414,11 @@ footer address {
     text-shadow: 1px 4px 2px #a5a5a5;
 }
 */
-/* Text Classes */
+
+/* Text Styles */
+.note {
+   font-style:italic;
+}
 .msg-label {
     font-weight: bold;
 }
@@ -434,6 +441,9 @@ footer address {
     color: #a5a5a5;
     text-decoration: underline;
 }
+.small-text {
+    font-size: 14px;
+}
 
 /* Image Styles */
 .profile-pic {
@@ -442,5 +452,13 @@ footer address {
 .profile-caption {
     font-size: 15px;
     text-align: center;
+}
+
+/* Custom (Background) Color Classes */
+.custom-blue {
+    background-color:#00B3FF;
+}
+.custom-green {
+    background-color: #72cb19;
 }
 

--- a/WaffleOffer/WaffleOffer/Controllers/ItemsController.cs
+++ b/WaffleOffer/WaffleOffer/Controllers/ItemsController.cs
@@ -110,6 +110,8 @@ namespace WaffleOffer.Controllers
                         where i.ListingType == type && i.ListingUser == userName
                         select i).ToList();
 
+
+
             return View(items);
         }
 

--- a/WaffleOffer/WaffleOffer/Views/Items/Edit.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Items/Edit.cshtml
@@ -55,14 +55,14 @@
 
         <div class="form-group">
             <div class="col-md-offset-2 col-md-10">
-                <input type="submit" value="Save" class="btn btn-default" />
+                <input type="submit" value="Save" class="btn btn-custom-submit" />
             </div>
         </div>
     </div>
 }
 
 <div>
-    @Html.ActionLink("Back to List", "Index")
+    @Html.ActionLink("Back to List", "Index", "Items", null, new { @class="btn btn-sm btn-custom-grey" })
 </div>
 
 @section Scripts {

--- a/WaffleOffer/WaffleOffer/Views/Items/Index.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Items/Index.cshtml
@@ -40,5 +40,4 @@
         </div>
     }
 </p>
-
-    @Html.Partial("ItemList", Model) <!-- Links to a partial view that holds the items table -->
+@Html.Partial("ItemList", Model) <!-- Links to a partial view that holds the items table -->

--- a/WaffleOffer/WaffleOffer/Views/Items/Items.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Items/Items.cshtml
@@ -6,7 +6,6 @@
 
 <h4 class="dark-heading">@ViewBag.TypeHeading</h4>
 
-
 <div class="col-xs-12 col-sm-6 col-md-4">
     <a href="@Url.Action("Create", "Items", new { type = Model.Type.ToString() })">
         <div class="card custom-card-short-grey hoverable">
@@ -18,15 +17,13 @@
 <table class="table table-hover">
     <tr>
         <th>
-            @Html.ActionLink("Item Name", "Index", new { sortOdr = ViewBag.NameSort }) @*<span class="glyphicon-sort-by-alphabet"></span>*@ <span class="caret"></span>
-            @*@Html.DisplayNameFor(model => model.Name)*@
+            @Html.ActionLink("Item Name", "Index", new { sortOdr = ViewBag.NameSort }) <span class="caret"></span>
         </th>
         <th>
             @Html.DisplayNameFor(model => model.ItemModel.Description)
         </th>
         <th>
             @Html.ActionLink("Quality", "Index", new { sortOdr = ViewBag.QualitySort })
-            @*@Html.DisplayNameFor(model => model.Quality)*@
         </th>
         <th>
             @Html.DisplayNameFor(model => model.ItemModel.Units)
@@ -37,6 +34,7 @@
 
         <th></th>
     </tr>
+
     @foreach (var item in Model.Items)
     {
         <tr>
@@ -72,6 +70,7 @@
             </td>
         </tr>
     }
+
 </table>
 <div>
     @Html.ActionLink("Back to Profile", "Index", "Profile", new { userName = @ViewBag.ListingUser }, new { @class="btn btn-sm btn-custom-grey" })

--- a/WaffleOffer/WaffleOffer/Views/Profile/Index.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Profile/Index.cshtml
@@ -11,8 +11,6 @@
             <figure>
                 <!-- profile img or placeholder avatar goes here-->
                 <img src="../Images/wo-temp-avatar-1.png" class="profile-pic" />
-                <!-- commented out until I can fix the garbage-looking alignment -->
-                <!--<figcaption class="profile-caption">-->@*@Html.DisplayFor(model => model.Nickname)*@ <!--</figcaption>-->
             </figure>
             @*Only other traders should be able to see this*@
             @if (User.Identity.Name != Model.Nickname)
@@ -24,16 +22,23 @@
         </div>
         <div class="col-md-8">
             <h5>About @Html.DisplayFor(model => model.Nickname)</h5>
-            <p>
-                @Html.DisplayFor(model => model.ProfileText)
-                @if (String.IsNullOrWhiteSpace(Model.ProfileText))
+            @if (String.IsNullOrWhiteSpace(Model.ProfileText))
+            {
+                <p class="note">
+                @if (User.Identity.Name == Model.Nickname)
                 {
-                    @:Lorem ipsum whateverum until there is some profile text or some placeholder
-                    @:something or other. Whatever.Lorem.Ipsum.Etcetera.Rosa rosae rosae rosam
-                    @:rosa(with a flat little hat) rosa.
+                    @: You haven't filled out this section yet.
                 }
-
-            </p>
+                else
+                {
+                    @: Trader has not yet filled in this section.
+                }
+                </p>
+            }
+            else 
+            {
+                <p>@Html.DisplayFor(model => model.ProfileText)</p>
+            }
             <p>
                 <strong>@Html.DisplayNameFor(model => model.ZipCode):</strong> @Html.DisplayFor(model => model.ZipCode)
             </p>
@@ -62,14 +67,14 @@
             </a>          
         </div>
         <div class="col-xs-12 col-sm-6 col-md-4">
-            <a href="@Url.Action("Create", "Items", new { type = "Have" })">
+            <a href="@Url.Action("Create", "Items", new { userName = Model.Nickname, type = "Have" })">
                 <div class="card custom-card-short-grey hoverable">
                     <h5 class="custom-card-short-heading"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span>&nbsp;Add a New Have</h5>
                 </div>
             </a>  
         </div>
         <div class="col-xs-12 col-sm-6 col-md-4">
-            <a href="@Url.Action("Create", "Items", new { type = "Want" })">
+            <a href="@Url.Action("Create", "Items", new { userName = Model.Nickname, type = "Want" })">
                 <div class="card custom-card-short-grey hoverable">
                     <h5 class="custom-card-short-heading"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span>&nbsp;Add a New Want</h5>
                 </div>
@@ -84,6 +89,7 @@
             </a>
         </div>     
         <div class="col-xs-12 col-sm-6 col-md-4">
+            <!-- THIS DOES NOT WORK ANYMORE. FIND OUT WTF IS HAPPENING WITH THE ITEMLIST MODEL -->
             <a href="@Url.Action("Items", "Items", new { userName = Model.Nickname, type= "Have" })">
                 <div class="card custom-card-orange hoverable animated slideInLeft">
                     <h4 class="custom-card-heading">Haves</h4>
@@ -92,6 +98,7 @@
             </a>
         </div>
         <div class="col-xs-12 col-sm-6 col-md-4">
+            <!-- THIS DOES NOT WORK ANYMORE. FIND OUT WTF IS HAPPENING WITH THE ITEMLIST MODEL -->
             <a href="@Url.Action("Items", "Items", new { userName = Model.Nickname, type= "Want" })">
                 <div class="card custom-card-red hoverable animated slideInLeft">
                     <h4 class="custom-card-heading">Wants</h4>
@@ -126,26 +133,37 @@
     @*Trader will not see this on their own page*@
     @if (User.Identity.Name != Model.Nickname || User.IsInRole("Admin"))
     {
-        <!-- TODO: Add Wants and needs to these lists dynamically. May require using a partial view. -->
         <div class="row">
             <div class="col-md-6">
                 <ul class="collection with-header">
                     <li class="collection-header list-header"><h5>Haves</h5></li>
-                    <li class="collection-item">Thing 1</li>
-                    <li class="collection-item">Thing 2</li>
-                    <li class="collection-item">Thing 3</li>
-                    <li class="collection-item">Thing 4</li>
+                    @if (Model.Haves.Count > 0)
+                    {
+                        @Html.Partial("ProfileHaves", Model.Haves)
+                    }
+                    else
+                    {
+                        <li class="collection-item">
+                            No haves listed.
+                        </li>
+                    }
                 </ul>
             </div>
             <div class="col-md-6">
                 <ul class="collection with-header">
                     <li class="collection-header list-header"><h5>Wants</h5></li>
-                    <li class="collection-item">Thing 1</li>
-                    <li class="collection-item">Thing 2</li>
-                    <li class="collection-item">Thing 3</li>
-                    <li class="collection-item">Thing 4</li>
+                    @if (Model.Wants.Count > 0)
+                    {
+                        @Html.Partial("ProfileWants", Model.Wants)
+                    }
+                    else
+                    {
+                        <li class="collection-item">
+                            No wants listed.
+                        </li>
+                    }
                 </ul>
             </div>
-        </div>  
+        </div>
     }
 </div>

--- a/WaffleOffer/WaffleOffer/Views/Shared/CompactTrade.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Shared/CompactTrade.cshtml
@@ -1,38 +1,73 @@
 ﻿@model WaffleOffer.Models.Trade
 
-<table class="table">
-    <tr>
-        <th>@Model.SendingTrader.UserName</th>
-        <th>
-            @Model.GetTradeStatusMessage(User.Identity.Name == Model.SendingTrader.UserName)
-        </th>
-        <th>@Model.ReceivingTrader.UserName</th>
-        <th></th>
-    </tr>
-    <tr>
-        <td>
-            <ul>
-                @foreach (var item in Model.SendingItems)
-                {
-                    <li>@item.Quantity x @item.Name</li>
-                }
-            </ul>
-        </td>
-        <td>
+<div class="panel panel-default">
+    <div class="col-md-3">
+        <h5 class="h5-responsive">@Model.SendingTrader.UserName</h5>
+        <br />
+        <ul>
+            @foreach (var item in Model.SendingItems)
+            {
+                <li>@item.Quantity x @item.Name</li>
+            }
+        </ul>
+    </div>
+    <div class="col-md-4">
+        <p class="small-text text-center">Status: @Model.GetTradeStatusMessage(User.Identity.Name == Model.SendingTrader.UserName)</p>
+        <div class="text-center">
             <i class="material-icons animated slideInLeft">arrow_forward</i>
             <br />
             <i class="material-icons animated slideInRight">arrow_back</i>
-        </td>
-        <td>
-            <ul>
-                @foreach (var item in Model.ReceivingItems)
-                {
-                    <li>@item.Quantity x @item.Name</li>
-                }
-            </ul>
-        </td>
-        <td>
-            @Html.ActionLink("View Trade", "Index", "Trade", new { partner = Model.ReceivingTrader.UserName, tradeId = Model.TradeId }, new { @class = "btn btn-sm btn-sender btn-custom-grey" })
-        </td>
-    </tr>
-</table>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <h5 class="h5-responsive">@Model.ReceivingTrader.UserName</h5>
+        <br />
+        <ul>
+            @foreach (var item in Model.ReceivingItems)
+            {
+                <li>@item.Quantity x @item.Name</li>
+            }
+        </ul>
+    </div>
+    <div class="col-md-2">
+        @Html.ActionLink("View Trade", "Index", "Trade", new { partner = Model.ReceivingTrader.UserName, tradeId = Model.TradeId }, new { @class = "btn btn-sm btn-sender btn-custom-grey" })
+    </div>
+</div>
+@*
+    <table class="table">
+        <tr>
+            <th>@Model.SendingTrader.UserName</th>
+            <th>
+                @Model.GetTradeStatusMessage(User.Identity.Name == Model.SendingTrader.UserName)
+            </th>
+            <th>@Model.ReceivingTrader.UserName</th>
+            <th></th>
+        </tr>
+        <tr>
+            <td>
+                <ul>
+                    @foreach (var item in Model.SendingItems)
+                    {
+                        <li>@item.Quantity x @item.Name</li>
+                    }
+                </ul>
+            </td>
+            <td>
+                <i class="material-icons animated slideInLeft">arrow_forward</i>
+                <br />
+                <i class="material-icons animated slideInRight">arrow_back</i>
+            </td>
+            <td>
+                <ul>
+                    @foreach (var item in Model.ReceivingItems)
+                    {
+                        <li>@item.Quantity x @item.Name</li>
+                    }
+                </ul>
+            </td>
+            <td>
+                @Html.ActionLink("View Trade", "Index", "Trade", new { partner = Model.ReceivingTrader.UserName, tradeId = Model.TradeId }, new { @class = "btn btn-sm btn-sender btn-custom-grey" })
+            </td>
+        </tr>
+    </table>
+*@

--- a/WaffleOffer/WaffleOffer/Views/Shared/ItemList.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Shared/ItemList.cshtml
@@ -21,7 +21,7 @@
         <th>
             @Html.DisplayNameFor(model => model.Quantity)
         </th>
-
+        <th>Owner</th>
         <th></th>
     </tr>
     @foreach (var item in Model)
@@ -43,8 +43,17 @@
                 @Html.DisplayFor(modelItem => item.Quantity)
             </td>
             <td>
-				@* Older buttons *@
-                @*<div class="btn-group">
+                @if (item.ListingUser == User.Identity.Name)
+                {
+                    @: You
+                }
+                else
+                {
+                    @Html.DisplayFor(modelItem => item.ListingUser)
+                }    
+            </td>
+            <td>
+                <div class="btn-group">
                     <button type="button" class="btn btn-sm btn-custom-grey dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Actions <span class="caret"></span>
                     </button>
@@ -56,30 +65,8 @@
                             <li>@Html.ActionLink("Delete", "Delete", "Items", new { id = item.ItemID }, null)</li>
                         }
                     </ul>
-                </div>*@ 
-
-                @Html.ActionLink("Details", "Details", "Items", new { id = item.ItemID }, new { @class = "btn btn-sm btn-custom-grey" })
-                @if (User.IsInRole("Admin") || User.Identity.Name == item.ListingUser)
-                {
-                    @*@Html.Raw(" | ");*@
-                    @Html.ActionLink("Edit", "Edit", "Items", new { id = item.ItemID }, new { @class = "btn btn-sm btn-custom-grey" })
-                    @*@Html.Raw(" | ");*@
-                    @Html.ActionLink("Delete", "Delete", "Items", new { id = item.ItemID }, new { @class = "btn btn-sm btn-custom-grey" })
-                }
+                </div>
             </td>
-
-            @* Unstyled CRUD links *@
-            @*<td>
-                @Html.ActionLink("Details", "Details", "Items", new { id = item.ItemID }, null)
-                @if (User.IsInRole("Admin") || User.Identity.Name == item.ListingUser)
-                {
-                    @Html.Raw(" | ");
-                    @Html.ActionLink("Edit", "Edit", "Items", new { id = item.ItemID }, null)
-                    @Html.Raw(" | ");
-                    @Html.ActionLink("Delete", "Delete", "Items", new { id = item.ItemID }, null )
-                }
-            </td>*@
-
         </tr>
     }
 </table>

--- a/WaffleOffer/WaffleOffer/Views/Shared/ProfileHaves.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Shared/ProfileHaves.cshtml
@@ -1,0 +1,18 @@
+﻿@model IEnumerable<WaffleOffer.Models.Item>
+
+@foreach (var item in Model)
+{
+    if (item.ListingType == Item.ItemType.Have)
+    {
+        <li class="collection-item">
+            <div class="text-left">
+                @Html.DisplayFor(modelItem => item.Name)
+            </div>
+            <div class="text-right">
+                @Html.ActionLink("View", "Details", "Items", new { id = item.ItemID }, new { @class = "btn btn-sm btn-custom-grey" })
+            </div>
+        </li>
+    }
+}
+
+

--- a/WaffleOffer/WaffleOffer/Views/Shared/ProfileWants.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Shared/ProfileWants.cshtml
@@ -1,0 +1,16 @@
+﻿@model IEnumerable<WaffleOffer.Models.Item>
+
+@foreach (var item in Model)
+{
+    if (item.ListingType == Item.ItemType.Want)
+    {
+        <li class="collection-item">
+            <div class="text-left">
+                @Html.DisplayFor(modelItem => item.Name)
+            </div>
+            <div class="text-right">
+                @Html.ActionLink("View", "Details", "Items", new { id = item.ItemID }, new { @class = "btn btn-sm btn-custom-grey" })
+            </div>
+        </li>
+    }
+}

--- a/WaffleOffer/WaffleOffer/Views/Trade/Index.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Trade/Index.cshtml
@@ -42,6 +42,10 @@
         }
         //append element to destination column
         document.getElementById(destColId).appendChild(item);
+
+        //show a message to the user if a column is empty
+        //does not seem to do anything. delete if cannot get to work.
+        //showNoItemsMessage(srcColId);
     }
 
     function submitTrade()
@@ -80,7 +84,6 @@
         document.getElementById("updateTrade").submit();
     }
 
-
     function addItems(column)
     {
         //get the column element
@@ -108,18 +111,53 @@
             }
         }
     }
+
+    function checkColumnEmpty(column) {
+        //get the column element
+        var col = document.getElementById(column);
+        if (col.childElementCount > 0)
+            return false;
+        else
+            return true;
+    }
+
+    // This isn't working... (Though it is not--as far as I can see--breaking anything)
+    function showNoItemsMessage(column) {
+        // check to see whether or not the column is empty
+        if (checkColumnEmpty(column)) {
+            // find the corresponding message paragraph tag id
+            var pId = "";
+            var msg = "";
+            switch (column) {
+                case "SenderHaves":
+                    pId = "msgSenderHaves";
+                    msg = "Nothing left in inventory.";
+                    break;
+                case "SenderOffers":
+                    pId = "msgSenderOffers";
+                    msg = "Nothing offered.";
+                    break;
+                case "ReceiverHaves":
+                    pId = "msgReceiverHaves";
+                    msg = "Nothing left in inventory.";
+                    break;
+                case "ReceiverOffers":
+                    pId = "msgReceiverOffers";
+                    msg = "Nothing offered.";
+                    break;
+            }
+            // Insert the appropriate message between the paragraph tags
+            // that correspond to the column passed in
+            document.getElementById(pId).innerHTML = msg;
+        }
+    }
 </script>
 
 <h4 class="dark-heading divider-new">Trade</h4>
-
+@*Commenting this bit out until group approves new trade aesthetic - Sally*@
+@*
 <table class="table">
     <tr>
-        @*
-        <th>Sender: @Html.DisplayFor(model => model.SendingTrader.UserName)</th>
-        <th>Offered by Sender</th>
-        <th>Offered by Receiver</th>
-        <th>Receiver: @Html.DisplayFor(model => model.ReceivingTrader.UserName)</th>
-        *@
         <th>@Html.DisplayFor(model => model.SendingTrader.UserName)</th>
         <th>@Html.DisplayFor(model => model.SendingTrader.UserName)'s Offer</th>
         <th>@Html.DisplayFor(model => model.ReceivingTrader.UserName)'s Offer</th>
@@ -169,47 +207,107 @@
         </td>
     </tr>
 </table>
+*@
+<div class="panel-group">
+    <div class="panel panel-default custom-blue">
+        <h5 class="h5-responsive text-center white-text">@Html.DisplayFor(model => model.SendingTrader.UserName) Inventory</h5>
+    </div>
+    <div class="panel panel-default">
+        <div id="SenderHaves">
+            <div class="clearfix"></div>
+            @foreach (var item in Model.SenderHaves)
+            {
+                <div id="@item.ItemID">
+                    <input type="button" class="btn btn-custom-grey btn-sender" onclick="moveItem(@item.ItemID)" value="@item.Name" />
+                </div>
+            }
+            <p id="msgSenderHaves"></p>
+        </div>
+    </div>
+    <div class="panel panel-default custom-blue">
+        <h5 class="h5-responsive text-center white-text">@Html.DisplayFor(model => model.SendingTrader.UserName)'s Offer</h5> 
+    </div>
+    <div class="panel panel-default">
+        <div id="SenderOffers">
+            @foreach (var item in Model.SendingItems)
+            {
+                <div id="@item.ItemID">
+                    <input type="button" class="btn btn-custom-grey btn-sender" onclick="moveItem(@item.ItemID)" value="@item.Name" />
+                </div>
+            }
+            <p id="msgSenderOffers"></p>
+        </div>
+    </div>
+    <div class="panel panel-default custom-green">
+        <h5 class="h5-responsive text-center white-text">@Html.DisplayFor(model => model.ReceivingTrader.UserName)'s Offer</h5>
+    </div>
+    <div class="panel panel-default" id="ReceiverOffers">
+        <div id="ReceiverOffers">
+            @foreach (var item in Model.ReceivingItems)
+            {
+                <div id="@item.ItemID">
+                    <input type="button" class="btn btn-custom-grey btn-receiver" onclick="moveItem(@item.ItemID)" value="@item.Name" />
+                </div>
+            }
+            <p id="msgReceiverOffers"></p>
+        </div>
+    </div>
+    <div class="panel panel-default custom-green">
+        <h5 class="h5-responsive text-center white-text">@Html.DisplayFor(model => model.ReceivingTrader.UserName) Inventory</h5>
+    </div>
+    <div class="panel panel-default" id="ReceiverHaves">
+        <div id="ReceiverHaves">
+            @foreach (var item in Model.ReceiverHaves)
+            {
+                <div id="@item.ItemID">
+                    <input type="button" class="btn btn-custom-grey btn-receiver" onclick="moveItem(@item.ItemID)" value="@item.Name" />
+                </div>
+            }
+            <p id="msgReceiverHaves"></p>
+        </div>
+    </div>
+</div>
 
 @if (!Model.Submitted || (!Model.Canceled && !Model.Rejected && !Model.Accepted 
     && Model.SendingTrader.UserName != User.Identity.Name))
 {
-    <button class="btn btn-block btn-custom-submit" onclick="submitTrade()">Submit Trade</button>
+    <button class="btn btn-custom-submit" onclick="submitTrade()">Submit Trade</button>
 }
 @if (Model.Submitted && (!Model.Canceled && !Model.Rejected && !Model.Accepted
                 && Model.SendingTrader.UserName != User.Identity.Name))
 {
-    <button class="btn btn-block btn-custom-submit" onclick="updateTrade('Accept')">Accept Trade</button>
-    <button class="btn btn-block btn-custom-submit" onclick="updateTrade('Reject')">Reject Trade</button>
+    <button class="btn btn-custom-submit" onclick="updateTrade('Accept')">Accept Trade</button>
+    <button class="btn btn-custom-submit" onclick="updateTrade('Reject')">Reject Trade</button>
 }
 @if (User.Identity.Name == Model.SendingTrader.UserName && Model.Submitted && !Model.Canceled && !Model.Accepted 
     && !Model.Rejected || (Model.Accepted && !Model.SenderConfirmed && !Model.ReceiverConfirmed))
 {
-    <button class="btn btn-block btn-custom-submit" onclick="updateTrade('Cancel')">Cancel Trade</button>
+    <button class="btn btn-custom-submit" onclick="updateTrade('Cancel')">Cancel Trade</button>
 }
 @if (Model.Accepted && ((User.Identity.Name == Model.SendingTrader.UserName && !Model.SenderConfirmed)
                 || (User.Identity.Name == Model.ReceivingTrader.UserName && !Model.ReceiverConfirmed)))
 {
-    <button class="btn btn-block btn-custom-submit" onclick="updateTrade('Confirm')">Confirm Trade</button>
+    <button class="btn btn-custom-submit" onclick="updateTrade('Confirm')">Confirm Trade</button>
 }
 @if (Model.SenderConfirmed && Model.ReceiverConfirmed && ((User.Identity.Name == Model.SendingTrader.UserName && Model.SenderRating == 0)
                             || (User.Identity.Name == Model.ReceivingTrader.UserName && Model.ReceiverRating == 0)))
 {
     @: Rate Trade: 
-    <button class="btn btn-block btn-custom-submit" onclick="updateTrade('1')">Poor</button>
-    <button class="btn btn-block btn-custom-submit" onclick="updateTrade('2')">Fair</button>
-    <button class="btn btn-block btn-custom-submit" onclick="updateTrade('3')">Good</button>
-    <button class="btn btn-block btn-custom-submit" onclick="updateTrade('4')">Great</button>
-    <button class="btn btn-block btn-custom-submit" onclick="updateTrade('5')">Perfect</button>
+    <button class="btn btn-custom-submit" onclick="updateTrade('1')">Poor</button>
+    <button class="btn btn-custom-submit" onclick="updateTrade('2')">Fair</button>
+    <button class="btn btn-custom-submit" onclick="updateTrade('3')">Good</button>
+    <button class="btn btn-custom-submit" onclick="updateTrade('4')">Great</button>
+    <button class="btn btn-custom-submit" onclick="updateTrade('5')">Perfect</button>
 }
 
-
+<br />
 @if (!Model.Submitted)
 {
-    <a href="@Url.Action("Index", "Items")">Back to List</a>
+    @Html.ActionLink("Back to List","Index", "Items", null, new { @class="btn btn-sm btn-custom-grey" })
 }
 else
 {
-    <a href="@Url.Action("List", "Trade")">Back to List</a>
+    @Html.ActionLink("Back to List", "List", "Trade", null, new { @class = "btn btn-sm btn-custom-grey" })
 }
 
 @using (Html.BeginForm("Create", "Trade", FormMethod.Post, new { id = "submitTrade" }))

--- a/WaffleOffer/WaffleOffer/Views/Trade/List.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Trade/List.cshtml
@@ -6,14 +6,23 @@
 
 <h4 class="dark-heading divider-new">Trades</h4>
 
-<table class="table">
+<div class="panel-group">
+    @foreach (var item in Model)
+    {
+        @Html.Partial("CompactTrade", item)
+    }
+</div>
 
-@foreach (var item in Model) {
-    <tr>
-        <td>
-            @Html.Partial("CompactTrade", item)
-        </td>
-    </tr>
-}
 
-</table>
+@*<table class="table">
+
+    @foreach (var item in Model) {
+        <tr>
+            <td>
+                @Html.Partial("CompactTrade", item)
+            </td>
+        </tr>
+    }
+
+    </table>
+*@

--- a/WaffleOffer/WaffleOffer/WaffleOffer.csproj
+++ b/WaffleOffer/WaffleOffer/WaffleOffer.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -131,6 +131,10 @@
       <Private>True</Private>
       <HintPath>..\packages\Newtonsoft.Json.5.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Vereyon.Web.FlashMessage, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Vereyon.Web.FlashMessage.1.0.1\lib\net40\Vereyon.Web.FlashMessage.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="WebGrease">
       <Private>True</Private>
       <HintPath>..\packages\WebGrease.1.5.2\lib\WebGrease.dll</HintPath>
@@ -165,6 +169,7 @@
     <Compile Include="Models\CreateItemViewModel.cs" />
     <Compile Include="Models\Item.cs" />
     <Compile Include="Models\ItemImage.cs" />
+    <Compile Include="Models\ItemList.cs" />
     <Compile Include="Models\ItemTag.cs" />
     <Compile Include="Models\LoginViewModel.cs" />
     <Compile Include="Models\Message.cs" />
@@ -195,6 +200,17 @@
     <Content Include="Scripts\bootstrap.js" />
     <Content Include="Scripts\bootstrap.min.js" />
     <Content Include="ClassDiagram1.cd" />
+    <Content Include="font\roboto\Roboto-Bold.woff" />
+    <Content Include="font\roboto\Roboto-Bold.woff2" />
+    <Content Include="font\roboto\Roboto-Light.woff" />
+    <Content Include="font\roboto\Roboto-Light.woff2" />
+    <Content Include="font\roboto\Roboto-Medium.woff" />
+    <Content Include="font\roboto\Roboto-Medium.woff2" />
+    <Content Include="font\roboto\Roboto-Regular.woff" />
+    <Content Include="font\roboto\Roboto-Regular.woff2" />
+    <Content Include="font\roboto\Roboto-Thin.woff" />
+    <Content Include="font\roboto\Roboto-Thin.woff2" />
+    <Content Include="MDB License.pdf" />
     <None Include="Properties\PublishProfiles\Waffle-Offer.pubxml" />
     <None Include="Scripts\jquery-1.10.2.intellisense.js" />
     <Content Include="Scripts\jquery-1.10.2.js" />
@@ -245,6 +261,8 @@
     <Content Include="Views\Trade\List.cshtml" />
     <Content Include="Views\Shared\CompactTrade.cshtml" />
     <Content Include="Views\Items\Items.cshtml" />
+    <Content Include="Views\Shared\ProfileHaves.cshtml" />
+    <Content Include="Views\Shared\ProfileWants.cshtml" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/WaffleOffer/WaffleOffer/Web.config
+++ b/WaffleOffer/WaffleOffer/Web.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=301880
@@ -9,8 +9,7 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
-    <add name="WaffleOfferContext" connectionString="Data Source=(localdb)\v11.0; Initial Catalog=WaffleOfferContext-1; Integrated Security=True; MultipleActiveResultSets=True; AttachDbFilename=|DataDirectory|WaffleOfferContext-1.mdf"
-      providerName="System.Data.SqlClient" />
+    <add name="WaffleOfferContext" connectionString="Data Source=(localdb)\v11.0; Initial Catalog=WaffleOfferContext-1; Integrated Security=True; MultipleActiveResultSets=True; AttachDbFilename=|DataDirectory|WaffleOfferContext-1.mdf" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />
@@ -19,7 +18,7 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <system.web>
-    <customErrors mode="Off"/><!--Remove me when deploying for real-->
+    <customErrors mode="Off" /><!--Remove me when deploying for real-->
     <compilation debug="true" targetFramework="4.5" />
     <httpRuntime targetFramework="4.5" />
   </system.web>
@@ -31,7 +30,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />

--- a/WaffleOffer/WaffleOffer/packages.config
+++ b/WaffleOffer/WaffleOffer/packages.config
@@ -21,5 +21,6 @@
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Respond" version="1.2.0" targetFramework="net45" />
+  <package id="Vereyon.Web.FlashMessage" version="1.0.1" targetFramework="net45" />
   <package id="WebGrease" version="1.5.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Changes:
-   trader wants and haves now display in outsider view
-   changed the width of the trade submit buttons
-   items Index view (or whatever partial), added Owner col and created actions dropdown
-   de-table-ized the Trade view, added a little color (can easily be removed, if y'all hate the colors)
-   de-table-ized the Trades Index view (not as pretty as I would like, but didn't want to do too much since Timo is possibly working on this, too)
-   Changed placeholder text for profiles

Things not done:
-   Make Add Have and Add Want buttons on the Haves and Wants pages smaller (the Items page now has bigger problems than this, what with something trying to pass in an ItemList object instead of a List<Item> situation and everything blowing up as a result)
-   Make sure rating is above zero (forgot where I was supposed to do this)
-   Beautification of the dropdown menu (with the search)
-   Browse users page
-   Link buttons on home page to actual things

Concerns/Bugs noticed:
-       Links to Haves and Wants on profile dashboard page broken now. I spent way too much time trying to fix it without success and so I would like the person who added the ItemsList model to fix these links, since it is not clear to me why this model exists or how it should be used.
-       Haves and Wants items now triplicating for mysterious reasons, may be messing up Trade
-       Trade items appear to no longer be attaching to trades. The triplication problem and this problem are likely related.
