### PR TITLE
Messaging bugfixes and made a few visual tweaks

### DIFF
--- a/WaffleOffer/WaffleOffer/Content/custom.css
+++ b/WaffleOffer/WaffleOffer/Content/custom.css
@@ -70,7 +70,7 @@ body {
     /*border-right: solid #a5a5a5 2px;*/
     margin-bottom: 0;
 }
-
+/*
 #landing-nav {
     font-weight: bold;
 }
@@ -98,7 +98,7 @@ body {
     border-bottom: 2px solid #f8b10e;
     box-shadow: 0 1px 0 0 #fff;
 }
-
+*/
 /* Heading Styles */
 .light-heading {
     color: #a5a5a5;
@@ -116,7 +116,7 @@ body {
 .jumbotron {
     background-color: #fff;
     /*border: solid #a5a5a5 2px;*/
-    margin: 50px 0 0 0;
+    margin: 50px 0;
 }
 .jumbotron img {
     height: auto;
@@ -126,7 +126,7 @@ body {
 
 /* Additional Home Page Styles */
 .landing-col {
-    padding: 15px;
+    padding: 30px;
 }
 
 .landing-col h4 {
@@ -135,7 +135,7 @@ body {
 }
 
 .landing-col p {
-    font-size: 18px;
+    font-size: 16px;
 }
 
 /* Footer Styles */

--- a/WaffleOffer/WaffleOffer/Migrations/Configuration.cs
+++ b/WaffleOffer/WaffleOffer/Migrations/Configuration.cs
@@ -127,6 +127,101 @@ namespace WaffleOffer.Migrations
             };
             
             context.Items.AddOrUpdate(i => i.Title, item1, item2, item3, item4);
+
+            var thread1 = new Thread() { ThreadID = 0 };
+            var thread2 = new Thread() { ThreadID = 1 };
+
+            context.Threads.AddOrUpdate(t => t.ThreadID, thread1, thread2);
+
+            DateTime date1 = new DateTime(2016, 6, 1, 1, 1, 1);
+            DateTime date2 = new DateTime(2016, 6, 1, 2, 2, 2);
+            DateTime date3 = new DateTime(2016, 6, 1, 3, 3, 3);
+
+            var msg1 = new Message()
+            {
+                SenderID = user2.Id,
+                RecipientID = user3.Id,
+                Subject = "RE: The Autobiography of Fred Durst",
+                Body = "Is Fred Durst related to Robert Durst? Because the musical travesty that is Limp Bizkit murdered my brain cells and got away with it.",
+                DateCreated = date1,
+                DateSent = date1,
+                Sent = true,
+                Copy = false,
+                IsReply = false,
+                ThreadID = thread1.ThreadID
+            };
+
+            var msg2 = new Message()
+            {
+                SenderID = user2.Id,
+                RecipientID = user3.Id,
+                Subject = "RE: The Autobiography of Fred Durst",
+                Body = "Is Fred Durst related to Robert Durst? Because the musical travesty that is Limp Bizkit murdered my brain cells and got away with it.",
+                DateCreated = date1,
+                DateSent = date1,
+                Sent = true,
+                Copy = true,
+                IsReply = false,
+                ThreadID = thread1.ThreadID
+            };
+
+            var msg3 = new Message()
+            {
+                SenderID = user3.Id,
+                RecipientID = user2.Id,
+                Subject = "RE: The Dursts",
+                Body = "No, but I think you can understand why I'm trying to unload this stupid book...",
+                DateCreated = date2,
+                DateSent = date2,
+                Sent = true,
+                Copy = false,
+                IsReply = true,
+                ThreadID = thread1.ThreadID
+            };
+
+            var msg4 = new Message()
+            {
+                SenderID = user3.Id,
+                RecipientID = user2.Id,
+                Subject = "RE: The Dursts",
+                Body = "No, but I think you can understand why I'm trying to unload this stupid book...",
+                DateCreated = date2,
+                DateSent = date2,
+                Sent = true,
+                Copy = true,
+                IsReply = true,
+                ThreadID = thread1.ThreadID
+            };
+
+            var msg5 = new Message()
+            {
+                SenderID = user3.Id,
+                RecipientID = user4.Id,
+                Subject = "Hi",
+                Body = "I like books.",
+                DateCreated = date3,
+                DateSent = date3,
+                Sent = true,
+                Copy = false,
+                IsReply = false,
+                ThreadID = thread2.ThreadID
+            };
+
+            var msg6 = new Message()
+            {
+                SenderID = user3.Id,
+                RecipientID = user4.Id,
+                Subject = "Hi",
+                Body = "I like books.",
+                DateCreated = date3,
+                DateSent = date3,
+                Sent = true,
+                Copy = true,
+                IsReply = false,
+                ThreadID = thread2.ThreadID
+            };
+
+            context.Messages.AddOrUpdate(m => m.MessageID, msg1, msg2, msg3, msg4, msg5, msg6);
             base.Seed(context);
         }
 

--- a/WaffleOffer/WaffleOffer/Models/Thread.cs
+++ b/WaffleOffer/WaffleOffer/Models/Thread.cs
@@ -13,7 +13,6 @@ namespace WaffleOffer.Models
 
         [Key]
         public int ThreadID { get; set; }
-        public List<Message> ThreadMessages { get { return messages; } set { messages = value; } }
 
         //flags/reports
         //flag type

--- a/WaffleOffer/WaffleOffer/Views/Home/Index.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Home/Index.cshtml
@@ -20,6 +20,7 @@
             </div>
         </div>
     </div>
+    @*
     <div class="row">
         <div class="navbar navbar-default" id="landing-nav">
             <div class="container">
@@ -48,6 +49,7 @@
             </div>
         </div>
     </div>
+    *@
     <div class="row">
         <div class="col-md-4 landing-col">
             <h4>Who</h4>

--- a/WaffleOffer/WaffleOffer/Views/Messages/Compose.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Messages/Compose.cshtml
@@ -17,12 +17,14 @@
         </ul>
     </div>
 </p>
+
+@Html.ValidationSummary(true)
+
 @using (Html.BeginForm())
 {
     @Html.AntiForgeryToken()
 
     <div class="form-horizontal">
-        @Html.ValidationSummary(true)
         @Html.HiddenFor(model => model.SenderItem)
         @Html.HiddenFor(model => model.DateCreated)
         @Html.HiddenFor(model => model.DateSent)
@@ -58,6 +60,8 @@
 }
 
 @section Scripts {
+    @Scripts.Render("~/bundles/jquery")
     @Scripts.Render("~/bundles/jqueryval")
+    @Scripts.Render("~/bundles/bootstrap")
 }
 

--- a/WaffleOffer/WaffleOffer/Views/Shared/ItemList.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Shared/ItemList.cshtml
@@ -58,10 +58,8 @@
                         <li>@Html.ActionLink("View", "Details", "Items", new { id = item.ItemID },null)</li>
                         @if (User.IsInRole("Admin") || User.Identity.Name == item.ListingUser)
                         {
-                            @Html.Raw(" | ");
-                            @Html.ActionLink("Edit", "Edit", "Items", new { id = item.ItemID }, null)
-                            @Html.Raw(" | ");
-                            @Html.ActionLink("Delete", "Delete", "Items", new { id = item.ItemID }, null )
+                            <li>@Html.ActionLink("Edit", "Edit", "Items", new { id = item.ItemID }, null)</li>
+                            <li>@Html.ActionLink("Delete", "Delete", "Items", new { id = item.ItemID }, null)</li>
                         }
                     </ul>
                 </div>

--- a/WaffleOffer/WaffleOffer/Views/Shared/_Layout.cshtml
+++ b/WaffleOffer/WaffleOffer/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-@using Vereyon.Web
+﻿@using Vereyon.Web
 
 <!DOCTYPE html>
 <html>
@@ -23,10 +23,10 @@
             </div>
             <div class="navbar-collapse collapse" id="top-nav">
                 <ul class="nav navbar-nav">
-                    <li class="custom-nav-item-both">@Html.ActionLink("Home", "Index", "Home")</li>
-                    <li class="custom-nav-item">@Html.ActionLink("About", "About", "Home")</li>
-                    <li class="custom-nav-item">@Html.ActionLink("Contact", "Contact", "Home")</li>
-                    <li class="custom-nav-item">@Html.ActionLink("Items", "Index", "Items")</li>
+                    <li class="custom-nav-item-both">@Html.ActionLink("Search", "Index", "Items")</li>
+                    <li class="custom-nav-item">@Html.ActionLink("Profiles", "Browse", "Profile")</li>
+                    <li class="custom-nav-item">@Html.ActionLink("Haves", "Browse", "Items", new { type = "Have" }, null)</li>
+                    <li class="custom-nav-item">@Html.ActionLink("Wants", "Browse", "Items", new { type = "Want" }, null)</li>
                 </ul>
                 <ul class="nav navbar-nav navbar-right">
                     @*Authentication links*@
@@ -68,8 +68,8 @@
             <div class="col-md-8">
                 <div class="col-md-3">
                     <ul>
-                        <li><a href="#">Home</a></li>
-                        <li><a href="#">About</a></li>
+                        <li>@Html.ActionLink("Home", "Index", "Home")</li>
+                        <li>@Html.ActionLink("About", "About", "Home")</li>
                         <li><a href="#">FAQ</a></li>
                     </ul>
                 </div>
@@ -81,7 +81,7 @@
                 </div>
                 <div class="col-md-3">
                     <ul>
-                        <li><a href="#">Contact Us</a></li>
+                        <li>@Html.ActionLink("Contact", "Contact", "Home")</li>
                         <li><a href="#">Support</a></li>
                     </ul>
                 </div>

--- a/WaffleOffer/WaffleOffer/WaffleOffer.csproj
+++ b/WaffleOffer/WaffleOffer/WaffleOffer.csproj
@@ -258,7 +258,6 @@
     <Content Include="Views\Shared\ItemList.cshtml" />
     <Content Include="Views\Trade\Index.cshtml" />
     <Content Include="Views\Messages\Delete.cshtml" />
-    <Content Include="Views\Messages\Edit.cshtml" />
     <Content Include="Views\Messages\Inbox.cshtml" />
     <Content Include="Views\Messages\Compose.cshtml" />
     <Content Include="Views\Messages\View.cshtml" />


### PR DESCRIPTION
- Fixed a bug where the latest message in a thread showed up as the message representing the thread on both the inbox and sent box pages. Now the inbox view displays the latest message for which the user is the recipient and the sent view displays the latest message for which the user us the sender.
- Linked some of the footer links to actual pages
- Changed the top navbar links to "Search", "Profiles", "Haves", and "Wants"
- Removed the secondary navbar on the front page. (commented out in case the team doesn't like it)
- A few other minor tweaks to the landing page
- Fixed a weird visual issue with the items actions dropdown.
- Seeded messages (and threads) in the database
